### PR TITLE
Get actual assemblyname instead of using filename

### DIFF
--- a/BepInEx.AssemblyPublicizer.MSBuild/PublicizeTask.cs
+++ b/BepInEx.AssemblyPublicizer.MSBuild/PublicizeTask.cs
@@ -144,7 +144,8 @@ public class PublicizeTask : Task
 
         foreach (var publicizedReference in publicizedReferences)
         {
-            var assemblyName = Path.GetFileNameWithoutExtension(publicizedReference.ItemSpec);
+            var assembly = FatalAsmResolver.FromFile(publicizedReference.ItemSpec);
+            var assemblyName = assembly.Name;
             stringBuilder.AppendLine($"[assembly: System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute(\"{assemblyName}\")]");
         }
 

--- a/BepInEx.AssemblyPublicizer/FatalAsmResolver.cs
+++ b/BepInEx.AssemblyPublicizer/FatalAsmResolver.cs
@@ -11,7 +11,7 @@ using AsmResolver.PE.Builder;
 
 namespace BepInEx.AssemblyPublicizer;
 
-internal static class FatalAsmResolver
+public static class FatalAsmResolver
 {
     /// Same as <see cref="AssemblyDefinition.FromFile(string)"/> but throws only on fatal errors
     public static AssemblyDefinition FromFile(string filePath)


### PR DESCRIPTION
In certain cases, the assembly name can be different from the file name.