### PR TITLE
Update to AsmResolver 6.0.0-beta.4

### DIFF
--- a/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
+++ b/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
@@ -49,7 +49,7 @@ public static class AssemblyPublicizer
                 if (!methodDefinition.HasMethodBody)
                     continue;
 
-                var newBody = methodDefinition.CilMethodBody = new CilMethodBody(methodDefinition);
+                var newBody = methodDefinition.CilMethodBody = new CilMethodBody();
                 newBody.Instructions.Add(CilOpCodes.Ldnull);
                 newBody.Instructions.Add(CilOpCodes.Throw);
                 methodDefinition.NoInlining = true;

--- a/BepInEx.AssemblyPublicizer/BepInEx.AssemblyPublicizer.csproj
+++ b/BepInEx.AssemblyPublicizer/BepInEx.AssemblyPublicizer.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.1" />
+        <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.4" />
         <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" Private="true"/>
     </ItemGroup>
 </Project>

--- a/BepInEx.AssemblyPublicizer/OriginalAttributesAttribute.cs
+++ b/BepInEx.AssemblyPublicizer/OriginalAttributesAttribute.cs
@@ -44,7 +44,7 @@ internal class OriginalAttributesAttribute
             );
             Type.Methods.Add(constructorDefinition);
 
-            var body = constructorDefinition.CilMethodBody = new CilMethodBody(constructorDefinition);
+            var body = constructorDefinition.CilMethodBody = new CilMethodBody();
             body.Instructions.Add(CilOpCodes.Ldarg_0);
             body.Instructions.Add(CilOpCodes.Call, baseConstructorReference);
             body.Instructions.Add(CilOpCodes.Ret);


### PR DESCRIPTION
Fixes issue where AsmResolver fails to read certain assemblies which would break BepInEx.AssemblyPublicizer from publicizing them. https://github.com/Washi1337/AsmResolver/pull/609

adjusted code to build with new AsmResolver 6 API changes

