### PR TITLE
asmresolver6: Fix IncludeOriginalAttributesAttribute being hardcoded to false on CLI

### DIFF
--- a/BepInEx.AssemblyPublicizer.Cli/PublicizeCommand.cs
+++ b/BepInEx.AssemblyPublicizer.Cli/PublicizeCommand.cs
@@ -48,7 +48,7 @@ public sealed class PublicizeCommand : RootCommand
         {
             Target = stripOnly ? PublicizeTarget.None : target,
             PublicizeCompilerGenerated = publicizeCompilerGenerated,
-            IncludeOriginalAttributesAttribute = false,
+            IncludeOriginalAttributesAttribute = !dontAddAttribute,
             Strip = stripOnly || strip,
         };
 


### PR DESCRIPTION
It meant that not only it ignored --dont-add-attribute, but it was always assumed to take effect even if it wasn't specified.

This is the same than the other PR, but for the asmresolver6 branch.