### PR TITLE
Fixed FormatException when trying to publicize the Photon assemblies in R.E.P.O.

### DIFF
--- a/BepInEx.AssemblyPublicizer.MSBuild/Extensions.cs
+++ b/BepInEx.AssemblyPublicizer.MSBuild/Extensions.cs
@@ -23,13 +23,6 @@ internal static class Extensions
             return false;
         }
 
-        // Fix a problem where when one tries to publicize PhotonRealtime, PhotonUnityNetworking,
-        // and PhotonUnityNetworking.Utilities from the R.E.P.O.GameLibs.Steam nuget package.
-        // Why is this needed? Because there are mods such as LateJoin that needs access to
-        // internal fields/methods to these Proton assemblies and avoiding reflection helps solve
-        // 100% of problems related to modding R.E.P.O. while not sacrificing performance.
-        // Also the fact that Reflection sucks and way too many bugs can happen with it.
-        // Problem seems to have existed from 0.4.1 according to git blame.
         metadata = taskItem.GetMetadata(metadataName);
         if (!string.IsNullOrWhiteSpace(metadata))
         {

--- a/BepInEx.AssemblyPublicizer.MSBuild/Extensions.cs
+++ b/BepInEx.AssemblyPublicizer.MSBuild/Extensions.cs
@@ -17,9 +17,22 @@ internal static class Extensions
 
     public static bool TryGetMetadata(this ITaskItem taskItem, string metadataName, [NotNullWhen(true)] out string? metadata)
     {
-        if (taskItem.HasMetadata(metadataName))
+        if (!taskItem.HasMetadata(metadataName))
         {
-            metadata = taskItem.GetMetadata(metadataName);
+            metadata = null;
+            return false;
+        }
+
+        // Fix a problem where when one tries to publicize PhotonRealtime, PhotonUnityNetworking,
+        // and PhotonUnityNetworking.Utilities from the R.E.P.O.GameLibs.Steam nuget package.
+        // Why is this needed? Because there are mods such as LateJoin that needs access to
+        // internal fields/methods to these Proton assemblies and avoiding reflection helps solve
+        // 100% of problems related to modding R.E.P.O. while not sacrificing performance.
+        // Also the fact that Reflection sucks and way too many bugs can happen with it.
+        // Problem seems to have existed from 0.4.1 according to git blame.
+        metadata = taskItem.GetMetadata(metadataName);
+        if (!string.IsNullOrWhiteSpace(metadata))
+        {
             return true;
         }
 


### PR DESCRIPTION
Refactor TryGetMetadata method to handle missing metadata correctly and improve comments regarding Photon assemblies.